### PR TITLE
Add CI workflows for develop and main branches

### DIFF
--- a/.github/workflows/action-tests-develop.yaml
+++ b/.github/workflows/action-tests-develop.yaml
@@ -1,0 +1,21 @@
+name: Pipeline Tests
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+jobs:
+  command-testes:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ contains(github.ref, 'develop') && 'development' || 'other' }}
+    if: github.ref == 'refs/heads/develop'
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - name: Discloud API Action - ${{ vars.ENV_NAME }} - Userinfo
+        uses: marco-quicula/discloud-api-action@develop
+        with:
+          discloud_api_token: ${{ secrets.DISCLOUD_API_TOKEN }}
+          command: 'userinfo'

--- a/.github/workflows/action-tests-main.yaml
+++ b/.github/workflows/action-tests-main.yaml
@@ -1,0 +1,21 @@
+name: Pipeline Tests
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  command-testes:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ contains(github.ref, 'main') && 'production' || 'other' }}
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - name: Discloud API Action - ${{ vars.ENV_NAME }} - Userinfo
+        uses: marco-quicula/discloud-api-action@main
+        with:
+          discloud_api_token: ${{ secrets.DISCLOUD_API_TOKEN }}
+          command: 'userinfo'


### PR DESCRIPTION
- Created a GitHub Actions workflow for the develop branch.
- Added a separate workflow for the main branch.
- Both workflows run on push events and support manual triggers.
- Each job checks out code and runs a Discloud API action with user info.